### PR TITLE
Release for v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [v0.1.5](https://github.com/kromiii/paper-to-notion/compare/v0.1.4...v0.1.5) - 2024-12-04
+
 ## [v0.1.4](https://github.com/kromiii/p2n/compare/v0.1.3...v0.1.4) - 2024-12-04
 
 ## [v0.1.3](https://github.com/kromiii/p2n/compare/v0.1.2...v0.1.3) - 2024-12-04

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "paper2notion",
   "description": "extract metadata from doi and export it to notion",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
This pull request is for the next release as v0.1.5 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.5 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.4" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->



**Full Changelog**: https://github.com/kromiii/paper-to-notion/compare/v0.1.4...v0.1.5