### PR TITLE
Release for v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.1.9](https://github.com/kromiii/paper-to-notion/compare/v0.1.8...v0.1.9) - 2025-01-22
+- Bump vite from 6.0.1 to 6.0.11 by @dependabot in https://github.com/kromiii/paper-to-notion/pull/13
+
 ## [v0.1.8](https://github.com/kromiii/paper-to-notion/compare/v0.1.7...v0.1.8) - 2024-12-10
 
 ## [v0.1.7](https://github.com/kromiii/paper-to-notion/compare/v0.1.6...v0.1.7) - 2024-12-04

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "paper2notion",
   "description": "A Chrome extension that imports paper metadata from Crossref to Notion using a DOI.",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "scripts": {
     "dev": "wxt",


### PR DESCRIPTION
This pull request is for the next release as v0.1.9 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.9 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.8" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Bump vite from 6.0.1 to 6.0.11 by @dependabot in https://github.com/kromiii/paper-to-notion/pull/13

## New Contributors
* @dependabot made their first contribution in https://github.com/kromiii/paper-to-notion/pull/13

**Full Changelog**: https://github.com/kromiii/paper-to-notion/compare/v0.1.8...v0.1.9